### PR TITLE
Notificacion absurda; insignias en el panel del admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # por hacer:
 
-- al compartir un enlace en facebook la meta data no llega al formulario de facebook (en facebook esto sale como "server error")
+- un autor no deberia de recibir una notificacion tras haber comentado en su propio post. la notificacion que recibe es de reinstitucion de comentario.
 
 DESPUES:
 - mejorar la vista de notificaciones

--- a/app/Filament/Resources/ReportResource.php
+++ b/app/Filament/Resources/ReportResource.php
@@ -8,6 +8,7 @@ use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Auth;
 use Filament\Infolists\Components\Grid;
 use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Builder;
@@ -103,7 +104,7 @@ class ReportResource extends Resource
     {
         return $table
             ->query(
-                static::getEloquentQuery()->with(['user', 'reportable']) // 👈 aquí cargas la relación
+                static::getEloquentQuery()->with(['user', 'reportable'])
             )
             ->columns([
                 TextColumn::make('reportable_type')
@@ -164,5 +165,15 @@ class ReportResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()->with('reportable');
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::count();
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'warning';
     }
 }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -130,4 +130,14 @@ class UserResource extends Resource
                 SoftDeletingScope::class,
             ]);
     }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return static::getModel()::count();
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'warning';
+    }
 }

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -23,7 +23,7 @@ class CommentController extends Controller
         $comment = $post->commentAsUser(Auth::user(), $request->comment);
         $comment->approve();
 
-        // disparar notificacion
+        // si el usuario que comenta, NO es el autor del post, enviar notificación
         if ($post->user->id !== Auth::id()) {
             $comment->load('commentable');
             $post->user->notify(new PostComment($comment));

--- a/app/Models/CustomComment.php
+++ b/app/Models/CustomComment.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Models\Post;
 use App\Models\User;
 use Kalnoy\Nestedset\NodeTrait;
+use Illuminate\Support\Facades\Auth;
 use App\Notifications\CommentModeration;
 use BeyondCode\Comments\Comment as BaseComment;
 
@@ -42,9 +43,12 @@ class CustomComment extends BaseComment
 
     public function approve()
     {
+        $wasApproved = $this->is_approved;
+
         parent::approve();
 
-        if ($this->commentator) {
+        // Solo notificar si el comentario NO estaba aprobado antes
+        if (!$wasApproved && $this->is_approved && $this->commentator && $this->commentator->id !== Auth::id()) {
             $this->commentator->notify(new CommentModeration($this, status: 'approved'));
         }
 

--- a/app/Traits/HandlesLikes.php
+++ b/app/Traits/HandlesLikes.php
@@ -16,12 +16,6 @@ trait HandlesLikes
             $post->likes()->firstOrCreate(['user_id' => Auth::id()]);
 
             if ($post->user_id !== Auth::id()) {
-                /* Log::info('Notificando al autor del post por like.', [
-                    'autor_id' => $post->user_id,
-                    'liker_id' => Auth::id(),
-                    'post_id' => $post->id,
-                ]); */
-
                 $post->user->notify(new PostLiked(Auth::user(), $post));
             }
     


### PR DESCRIPTION
Se arreglo una lógica que disparaba una notificación de "comentario reinstituido" cuando un autor comentaba en su propio post.

Se agrego una insignia para mostrar el número de reportes y el numero de usuarios en admin panel